### PR TITLE
Extract routes from middlewere installed Router

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,14 @@ module.exports = function (app, mongoose) {
                     if (!_.isUndefined(route.route)) {
                         route.route.method = Object.keys(route.route.methods).toString();
                         arr.push(route.route);
+                    } else if(route.handle.stack) {
+                        // Extract routes from middlewere installed Router
+                        _.each(route.handle.stack, function (route) {
+                            if (!_.isUndefined(route.route)) {
+                                route.route.method = Object.keys(route.route.methods).toString();
+                                arr.push(route.route);
+                            }
+                        });
                     }
                 });
                 routes = arr;


### PR DESCRIPTION
Hi if the express app routes are installed with a middlewere router, like this:

```
 app.use('/v1', apps_routes);
```

urls doesn't show in the generated docs, this fixes that
give it a try
